### PR TITLE
list all services in nav dropdown, scroll when too long

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,3 +3,9 @@
 body {
   font-family: "DM Sans", sans-serif;
 }
+
+.dropdown-menu.show {
+  display: block;
+  max-height: 75vh;
+  overflow-y: auto;
+}

--- a/src/lib/api/service.ts
+++ b/src/lib/api/service.ts
@@ -22,7 +22,12 @@ export async function fetchServices() {
   const response = await (
     API.post({
       apiName: "auth",
-      path: "/getServices"
+      path: "/getServices",
+      options: {
+        body: {
+          limit: 1000
+        }
+      }
     }).response
   )
   const serviceTypes: ServiceType[] =


### PR DESCRIPTION
- up to 1000 services will be returned from the API call to `/getServices`
- if dropdown list is longer than 75vh, it becomes scrollable