### PR TITLE
fix duplicate service test logic

### DIFF
--- a/src/lib/components/EditServiceForm.tsx
+++ b/src/lib/components/EditServiceForm.tsx
@@ -17,12 +17,19 @@ export default function EditServiceForm({
   setShowEditServiceModal
 } : EditServiceFormProps) {
   const navigate = useNavigate();
-  const [newServiceName, setNewServiceName] = useState<String>("");
-  const [newQuota, setNewQuota] = useState<Number>();
+  const [newServiceName, setNewServiceName] = useState<string>(service.name);
+  const [newQuota, setNewQuota] = useState<number | null>(hasQuota);
   const [feedback, setFeedback] = useState({
     text: "",
     isError: false,
   })
+
+  function hasQuota() {
+    if (service.quota) {
+      return service.quota
+    }
+    return null;
+  }
 
   const handleClose = () => { setShowEditServiceModal(false) }
 
@@ -73,7 +80,7 @@ export default function EditServiceForm({
         <h2 className="mb-3">Edit Service</h2>
 
         <FeedbackMessage
-          message={feedback} 
+          message={feedback}
           className="my-3"
         />
 
@@ -82,6 +89,7 @@ export default function EditServiceForm({
             <Form.Control
               type="text"
               onChange={(e) => setNewServiceName(e.target.value)}
+              value={newServiceName}
               placeholder="New Service Name"
             />
           </Form.Group>
@@ -90,6 +98,7 @@ export default function EditServiceForm({
             <Form.Control
               type="number"
               onChange={(e) => setNewQuota(parseInt(e.target.value))}
+              value={`${Number.isNaN(newQuota) ? '' : newQuota}`}
               placeholder="Optional Quota"
             />
           </Form.Group>

--- a/src/lib/components/EditServiceForm.tsx
+++ b/src/lib/components/EditServiceForm.tsx
@@ -35,8 +35,11 @@ export default function EditServiceForm({
       return;
     }
 
-    let duplicateService = services.some((service) => service.name === newServiceName)
-    if (duplicateService) {
+    if (isDuplicateService(
+      service,
+      services,
+      newServiceName
+    )) {
       setFeedback({
         text: "Service already exists.",
         isError: true
@@ -108,4 +111,22 @@ export default function EditServiceForm({
       </div>
     </>
   )
+}
+
+function isDuplicateService(
+  service: ServiceType,
+  services: ServiceType[],
+  newServiceName: String
+): boolean {
+  if (newServiceName.toLowerCase() === service.name.toLowerCase()) {
+    return false;
+  }
+  let duplicateService = services.some(
+    (service) =>
+      service.name.toLowerCase() === newServiceName.toLowerCase()
+  )
+  if (duplicateService) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
resolves issue #137 

- if service name is same, it is not treated as a duplicate service
- case insensitive, if user uses different letter casing but same service name it will not create a new service
- form pre-populated with current name and quota