### PR TITLE
remove guest ID and display slot start time on service page

### DIFF
--- a/src/lib/components/CompletedTable.tsx
+++ b/src/lib/components/CompletedTable.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { readableDateTime } from '../utils';
 import { updateGuestServiceStatus } from '../api';
@@ -11,7 +11,6 @@ interface CompletedTableProps {
 
 export default function CompletedTable({ guestsCompleted }: CompletedTableProps) {
   const queryClient = useQueryClient();
-  const navigate = useNavigate()
 
   const { mutateAsync: moveToQueuedMutation } = useMutation({
     mutationFn: (guest: GuestResponse): Promise<number> =>

--- a/src/lib/components/CompletedTable.tsx
+++ b/src/lib/components/CompletedTable.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from '@tanstack/react-router';
+import { Link, useNavigate } from '@tanstack/react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { readableDateTime } from '../utils';
 import { updateGuestServiceStatus } from '../api';
@@ -28,7 +28,6 @@ export default function CompletedTable({ guestsCompleted }: CompletedTableProps)
         <thead>
           <tr>
             <th>Time Requested</th>
-            <th>Guest ID</th>
             <th>Guest Name</th>
             <th>Actions</th>
           </tr>
@@ -42,8 +41,11 @@ export default function CompletedTable({ guestsCompleted }: CompletedTableProps)
               return (
                 <tr key={`${guest.guest_id}-${i}`}>
                   <td>{timeRequested}</td>
-                  <td onClick={() => navigate({ to: `/guests/${guest.guest_id}` })}>{guest.guest_id}</td>
-                  <td onClick={() => navigate({ to: `/guests/${guest.guest_id}` })}>{fullName}</td>
+                  <td>
+                    <Link to="/guests/$guestId" params={{ guestId: guest.guest_id }}>
+                      {fullName}
+                    </Link>
+                  </td>
                   <td>
                     <Button
                       variant="outline-primary"

--- a/src/lib/components/OccupiedSlotCard.tsx
+++ b/src/lib/components/OccupiedSlotCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import { useNavigate } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { Timer } from '.'
+import { readableTime } from '../utils';
 import { updateGuestServiceStatus } from '../api';
 import {
   Button,
@@ -22,7 +22,6 @@ export default function OccupiedSlotCard({
   slotNum
 }: OccupiedSlotCardProps) {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const [isExpired, setIsExpired] = useState(false);
 
   const { mutateAsync: moveToCompletedMutation } = useMutation({
@@ -41,7 +40,7 @@ export default function OccupiedSlotCard({
     }
   })
 
-  const nameAndID = `(${guest?.guest_id}) ${guest?.first_name} ${guest?.last_name}`;
+  const fullName = `${guest?.first_name} ${guest?.last_name}`;
   const slotStart = guest.slotted_at
   const slotStatusColor = isExpired ? "danger" : "warning"
   const slotIndicatorStyle = `bg-${slotStatusColor} rounded d-flex justify-content-center align-items-center`
@@ -57,18 +56,15 @@ export default function OccupiedSlotCard({
                 xs={6}
                 className="d-flex flex-column justify-content-between fs-5"
               >
-                <span onClick={() => navigate({ to: `/guests/${guest.guest_id}` })}>{nameAndID}</span>
-                {/* TIMER DISPLAY FOR FUTURE RELEASE
-                {serviceName === "Shower" && (
-                  <>
-                    // Default length of shower is 20min
-                    <Timer
-                      slotStart={slotStart!}
-                      slotTimeLength={20}
-                      setIsExpired={setIsExpired}
-                    ></Timer>
-                  </>
-                )} */}
+                <span>
+                  <Link to="/guests/$guestId" params={{ guestId: guest.guest_id }}>
+                    {fullName}
+                  </Link>
+                </span>
+                <p>
+                  start:
+                  <span className='fst-italic'>{` ${readableTime(slotStart)}`}</span>
+                </p>
               </Col>
               <Col xs={5} className="d-flex flex-row justify-content-end">
                 <Button

--- a/src/lib/components/QueuedTable.tsx
+++ b/src/lib/components/QueuedTable.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { readableDateTime } from "../utils";
 import { updateGuestServiceStatus } from "../api";
@@ -22,7 +22,6 @@ export default function QueuedTable({
   service,
 }: QueuedTableProps) {
   const queryClient = useQueryClient();
-  const navigate = useNavigate();
   const [assignmentDisabled, setAssignmentDisabled] = useState<boolean>(true);
   const [slotIntentions, setSlotIntentions] =
     useState<SlotIntention[]>(createSlotIntentionObjects);
@@ -115,7 +114,7 @@ export default function QueuedTable({
                 <tr key={`${guest.guest_id}-${i}`}>
                   <td>{i + 1}</td>
                   <td>{timeRequested}</td>
-                  <td onClick={() => navigate({ to: `/guests/${guest.guest_id}` })}>
+                  <td>
                     <Link to="/guests/$guestId" params={{ guestId: guest.guest_id }}>
                       {fullName}
                     </Link>

--- a/src/lib/components/QueuedTable.tsx
+++ b/src/lib/components/QueuedTable.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useNavigate } from "@tanstack/react-router";
+import { Link, useNavigate } from "@tanstack/react-router";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { readableDateTime } from "../utils";
 import { updateGuestServiceStatus } from "../api";
@@ -101,7 +101,6 @@ export default function QueuedTable({
           <tr>
             <th>#</th>
             <th>Time Requested</th>
-            <th>Guest ID</th>
             <th>Guest Name</th>
             <th>Actions</th>
           </tr>
@@ -116,8 +115,11 @@ export default function QueuedTable({
                 <tr key={`${guest.guest_id}-${i}`}>
                   <td>{i + 1}</td>
                   <td>{timeRequested}</td>
-                  <td onClick={() => navigate({ to: `/guests/${guest.guest_id}` })}>{guest.guest_id}</td>
-                  <td onClick={() => navigate({ to: `/guests/${guest.guest_id}` })}>{fullName}</td>
+                  <td onClick={() => navigate({ to: `/guests/${guest.guest_id}` })}>
+                    <Link to="/guests/$guestId" params={{ guestId: guest.guest_id }}>
+                      {fullName}
+                    </Link>
+                  </td>
                   <td>
                     <div className="d-flex flex-column justify-content-end">
                       {service.quota ? (

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -13,9 +13,25 @@ export function readableDateTime(ISODateString: string): string {
     year: "numeric",
     month: "numeric",
     day: "numeric",
+    hour: 'numeric',
+    minute: 'numeric',
+    second: undefined,
+    hour12: true
   };
 
-  return `${ISODate.toLocaleDateString("en-US", options)} ${ISODate.toLocaleTimeString("en-US")}`;
+  return ISODate.toLocaleTimeString("en-US", options);
+}
+
+export function readableTime(ISODateString: string): string {
+  const ISODate = new Date(ISODateString);
+  const options: Intl.DateTimeFormatOptions = {
+    hour: 'numeric',
+    minute: 'numeric',
+    second: undefined,
+    hour12: true
+  };
+
+  return ISODate.toLocaleTimeString("en-US", options);
 }
 
 export function isEven(num) {


### PR DESCRIPTION
Resolves #170 and #171

- remove seconds from time displays

![image](https://github.com/user-attachments/assets/337bf6e9-5c15-4cbc-9a43-a8667ab88eb2)
