### PR TITLE
Feat: Add Notification in New Visit View (plus heavy refactor)

### DIFF
--- a/src/lib/api/guest.ts
+++ b/src/lib/api/guest.ts
@@ -4,13 +4,19 @@ import * as API from "aws-amplify/api";
 import { pageOffset } from "../utils";
 
 export async function addGuest(g: Partial<Guest>): Promise<number | null> {
-  const response = await API.post({
-    apiName: "auth",
-    path: "/addGuest",
-    options: { body: { ...(g as FormData) } },
-  }).response;
-  const { guest_id }: { guest_id: number } = await response.body.json();
-  return guest_id;
+  try {
+    const response = await API.post({
+      apiName: "auth",
+      path: "/addGuest",
+      options: { body: { ...(g as FormData) } },
+    }).response;
+    const { guest_id } =
+      (await response.body.json()) as any as AddGuestAPIResponse;
+    return guest_id;
+  } catch (err) {
+    console.error("There was a problem adding the guest:", err);
+    return null;
+  }
 }
 
 export async function updateGuest(g: Partial<Guest>): Promise<boolean> {
@@ -18,13 +24,13 @@ export async function updateGuest(g: Partial<Guest>): Promise<boolean> {
     const response = await API.post({
       apiName: "auth",
       path: "/updateGuest",
-      options: { body: { ...(g as FormData) }},
+      options: { body: { ...(g as FormData) } },
     }).response;
-    const { success } = (await response.body.json()) as SuccessResponse
+    const { success } = (await response.body.json()) as any as SuccessResponse;
     return success;
   } catch (err) {
-    console.error(err)
-    return false
+    console.error("There was a problem updating the guest:", err);
+    return false;
   }
 }
 
@@ -33,38 +39,48 @@ export async function deleteGuest(id): Promise<boolean> {
     const response = await API.post({
       apiName: "auth",
       path: "/deleteGuest",
-      options: { body: { guest_id: id }},
+      options: { body: { guest_id: id } },
     }).response;
-    const { success } = (await response.body.json()) as SuccessResponse
+    const { success } = (await response.body.json()) as any as SuccessResponse;
     return success;
   } catch (err) {
-    console.error(err)
-    return false
+    console.error("There was a problem deleting the guest:", err);
+    return false;
   }
 }
 
-export async function getGuestData(id: number): Promise<GuestDataAPIResponse> {
-  const response = await API.post({
-    apiName: "auth",
-    path: "/getGuestData",
-    options: { body: { guest_id: id } },
-  }).response;
-  const guestResponse = (await response.body.json()) as GuestDataAPIResponse;
-  return guestResponse;
+export async function getGuestData(
+  id: number
+): Promise<GuestDataAPIResponse | null> {
+  try {
+    const response = await API.post({
+      apiName: "auth",
+      path: "/getGuestData",
+      options: { body: { guest_id: id } },
+    }).response;
+    return (await response.body.json()) as any as GuestDataAPIResponse;
+  } catch (err) {
+    console.error("There was a problem getting the guests's data:", err);
+    return null;
+  }
 }
 
 export async function getGuests(
   pageNum: number,
   limit = 10
-): Promise<GuestsAPIResponse> {
-  const offset = pageOffset(pageNum);
-  const response = await API.post({
-    apiName: "auth",
-    path: "/getGuests",
-    options: { body: { offset, limit } },
-  }).response;
-  const guestsResponse = (await response.body.json()) as GuestsAPIResponse;
-  return guestsResponse;
+): Promise<GuestsAPIResponse | null> {
+  try {
+    const offset = pageOffset(pageNum);
+    const response = await API.post({
+      apiName: "auth",
+      path: "/getGuests",
+      options: { body: { offset, limit } },
+    }).response;
+    return (await response.body.json()) as any as GuestsAPIResponse;
+  } catch (err) {
+    console.error("There was a problem getting guests:", err);
+    return null;
+  }
 }
 
 export async function getGuestsData(
@@ -78,21 +94,26 @@ export async function getGuestsData(
       path: "/getGuestsData",
       options: { body: { offset, limit } },
     }).response;
-    const guestsResponse = (await response.body.json()) as GuestsAPIResponse;
-    return guestsResponse;
+    return (await response.body.json()) as any as GuestsAPIResponse;
   } catch (err) {
-    console.log(err)
-    return null
+    console.log("There was a problem getting guests data:", err);
+    return null;
   }
 }
 
 /** Get guests with search query - first, last, dob, id. */
-export async function getGuestsWithQuery(query): Promise<GuestsAPIResponse> {
-  const response = await API.post({
-    apiName: "auth",
-    path: "/getGuests",
-    options: { body: { query, offset: 0, limit: 50_000 } },
-  }).response;
-  const guestsResponse = (await response.body.json()) as GuestsAPIResponse;
-  return guestsResponse;
+export async function getGuestsWithQuery(
+  query
+): Promise<GuestsAPIResponse | null> {
+  try {
+    const response = await API.post({
+      apiName: "auth",
+      path: "/getGuests",
+      options: { body: { query, offset: 0, limit: 50_000 } },
+    }).response;
+    return (await response.body.json()) as any as GuestsAPIResponse;
+  } catch (err) {
+    console.error("There was a problem querying guests:", err);
+    return null;
+  }
 }

--- a/src/lib/api/notification.ts
+++ b/src/lib/api/notification.ts
@@ -11,10 +11,47 @@ export async function toggleGuestNotificationStatus(
       path: "/toggleGuestNotificationStatus",
       options: { body: { notification_id: notificationId } },
     }).response;
-    const { success } = (await response.body.json()) as SuccessResponse;
+    const { success } = (await response.body.json()) as any as SuccessResponse;
     return success;
   } catch (err) {
-    console.error(err)
-    return false
+    console.error(err);
+    return false;
+  }
+}
+
+export async function addGuestNotification(
+  n: GuestNotification
+): Promise<number | null> {
+  try {
+    const response = await API.post({
+      apiName: "auth",
+      path: "/addGuestNotification",
+      options: { body: { ...n, status: "Active" } },
+    }).response;
+    const { notification_id } =
+      (await response.body.json()) as any as AddGuestNotificationAPIResponse;
+    return notification_id;
+  } catch (err) {
+    console.error("There was a problem adding the notification:", err);
+    return null;
+  }
+}
+
+export async function getGuestNotifications(
+  guest_id: number
+): Promise<GuestNotificationsAPIResponse | null> {
+  try {
+    const response = await API.post({
+      apiName: "auth",
+      path: "/getGuestNotifications",
+      options: { body: { guest_id } },
+    }).response;
+    return (await response.body.json()) as any as GuestNotificationsAPIResponse;
+  } catch (err) {
+    console.error(
+      "There was a problem getting the guests's notifications:",
+      err
+    );
+    return null;
   }
 }

--- a/src/lib/components/NewGuestForm.tsx
+++ b/src/lib/components/NewGuestForm.tsx
@@ -1,24 +1,28 @@
-import { Button, Form } from "react-bootstrap";
-import { FeedbackMessage } from "./";
-import { guestFormRequirementsSatisfied, today } from "../utils";
 import { useState } from "react";
+import { Button, Form } from "react-bootstrap";
+import { addGuest, getGuestData } from "../api";
+import {
+  blankUserMessage,
+  guestFormRequirementsSatisfied,
+  today,
+  trimStringValues,
+} from "../utils";
+import { FeedbackMessage } from "./";
 
 interface NewGuestFormProps {
-  onSubmit: (guest: Partial<Guest>) => Promise<number | null>;
-  onClose: () => void;
+  onSubmit: (newGuest: Guest | Partial<Guest>) => void;
+  onCancel: () => void;
 }
 
-// TODO: require at least N fields to be filled (currently 2)
-export default function NewGuestForm(props: NewGuestFormProps) {
-  const { onSubmit, onClose } = props;
-  const [formFeedback, setFormFeedback] = useState<UserMessage>({
-    text: "",
-    isError: false,
-  });
+export default function NewGuestForm({
+  onSubmit,
+  onCancel,
+}: NewGuestFormProps) {
+  const [feedback, setFeedback] = useState<UserMessage>(blankUserMessage());
   return (
     <div className="p-3">
       <h2 className="mb-3">Add New Guest</h2>
-      <FeedbackMessage message={formFeedback} className="my-3" />
+      <FeedbackMessage message={feedback} className="my-3" />
       <Form onSubmit={async (e) => await submitForm(e)}>
         <Form.Group className="mb-3">
           <Form.Label>First Name</Form.Label>
@@ -43,7 +47,7 @@ export default function NewGuestForm(props: NewGuestFormProps) {
           <Form.Control id="input-case-manager" name="case_manager" />
         </Form.Group>
         <div className="d-flex justify-content-between">
-          <Button variant="danger" type="button" onClick={onClose}>
+          <Button variant="danger" type="button" onClick={onClickCancel}>
             Cancel
           </Button>
           <Button variant="primary" type="submit">
@@ -54,27 +58,35 @@ export default function NewGuestForm(props: NewGuestFormProps) {
     </div>
   );
 
+  function onClickCancel() {
+    if (!confirm("Discard the new guest?")) return;
+    onCancel();
+  }
+
   async function submitForm(e) {
     e.preventDefault();
-    const guest = Object.fromEntries(new FormData(e.target)) as Partial<Guest>;
-    if (!guestFormRequirementsSatisfied(guest)) {
-      setFormFeedback({
+    const partialGuest = Object.fromEntries(
+      new FormData(e.target)
+    ) as Partial<Guest>;
+    trimStringValues(partialGuest);
+    if (!guestFormRequirementsSatisfied(partialGuest)) {
+      setFeedback({
         text: "At least 2 of the following are required: First Name, Last Name, Birthday",
         isError: true,
       });
       return;
-    } else {
-      setFormFeedback({ text: "", isError: false });
     }
-    const guest_id = await onSubmit(guest);
+    const guest_id = await addGuest(partialGuest);
     if (!guest_id) {
-      setFormFeedback({
+      setFeedback({
         text: "Failed to create guest. Try again in a few.",
         isError: true,
       });
       return;
-    } else {
-      setFormFeedback({ text: "", isError: false });
     }
+    setFeedback(blankUserMessage());
+    const { total, ...guest } = (await getGuestData(guest_id))!;
+    !total && console.error("There was a problem getting the guest's data.");
+    onSubmit(guest ?? { ...partialGuest, guest_id });
   }
 }

--- a/src/lib/components/UserProfile.tsx
+++ b/src/lib/components/UserProfile.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 import { Button, Form } from "react-bootstrap";
 import { FeedbackMessage } from "../components";
 import { deleteUser, updateUser } from "../api";
-import { trimStringValues } from "../utils";
+import { paddedId, trimStringValues } from "../utils";
 
 interface Props {
   user: User;
@@ -91,7 +91,7 @@ function UserForm({ user, isOwnAccount, setFeedback }: UFProps) {
         await saveEditedUser(e)
       }
     >
-      <h4>ID: {user.user_id.toString().padStart(5, "0")}</h4>
+      <h4>ID: {paddedId(user.user_id)}</h4>
       <Form.Group className="mb-3">
         <Form.Label className="fst-italic">Full Name</Form.Label>
         <Form.Control

--- a/src/lib/utils/guestOpts.ts
+++ b/src/lib/utils/guestOpts.ts
@@ -1,14 +1,18 @@
-/** Make string for option label */
-export function guestOptLabel(g: Guest) {
-  return `${g.guest_id} : ${g.first_name} ${g.last_name} : ${g.dob}`;
-}
+import { paddedId } from "./util";
 
 /** Map guests to `Select` options */
-export function guestLookupOpts(guests: Guest[]): ReactSelectOption[] {
-  return guests.map((g) => {
-    return {
-      value: g.guest_id.toString(),
-      label: guestOptLabel(g),
-    };
-  });
+export function guestSelectOptsFrom(guests: Guest[]): GuestSelectOption[] {
+  return guests.map((g) => guestSelectOptionFrom(g));
+}
+
+export function guestSelectOptionFrom(
+  guest: Guest | Partial<Guest>
+): GuestSelectOption {
+  return { value: String(guest.guest_id), label: guestOptLabel(guest), guest };
+}
+
+/** Make string for option label */
+export function guestOptLabel(g: Guest | Partial<Guest>) {
+  const NOT_PROVIDED = "[Not Provided]";
+  return `${paddedId(g.guest_id!)} : ${g.first_name ?? NOT_PROVIDED} ${g.last_name ?? NOT_PROVIDED} : ${g.dob ?? NOT_PROVIDED}`;
 }

--- a/src/lib/utils/util.ts
+++ b/src/lib/utils/util.ts
@@ -100,11 +100,10 @@ export function guestFormRequirementsSatisfied(guest: Partial<Guest>): boolean {
   return requiredCount >= MIN_REQUIRED_COUNT;
 }
 
-export function convertServiceTypeToOption(
-  service: ServiceType
-): ReactSelectOption {
-  return {
-    value: service.service_id.toString(),
-    label: service.name,
-  };
+export function paddedId(id: number): string {
+  return id.toString().padStart(5, "0");
+}
+
+export function blankUserMessage(): UserMessage {
+  return { text: "", isError: false }
 }

--- a/src/routes/_auth.guests_.$guestId.tsx
+++ b/src/routes/_auth.guests_.$guestId.tsx
@@ -8,7 +8,7 @@ import {
   Services,
 } from "../lib/components";
 import { deleteGuest, getGuestData } from "../lib/api";
-import { sortByTimeDescending } from "../lib/utils";
+import { paddedId, sortByTimeDescending } from "../lib/utils";
 
 interface LoaderData {
   guest: Guest;
@@ -94,7 +94,7 @@ export default function GuestProfileView() {
     isError: false,
   });
 
-  const guestId = guest.guest_id.toString().padStart(5, "0");
+  const guestId = paddedId(guest.guest_id);
 
   return (
     <>

--- a/src/routes/_auth.new-notification.tsx
+++ b/src/routes/_auth.new-notification.tsx
@@ -1,101 +1,90 @@
-import { useState } from 'react'
-import { createFileRoute } from '@tanstack/react-router'
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
 
-import * as API from 'aws-amplify/api'
+import * as API from "aws-amplify/api";
 
-import { FeedbackMessage, GuestSelectSearch } from '../lib/components'
+import { FeedbackMessage, GuestSelectSearch } from "../lib/components";
 import { Button, Form } from "react-bootstrap";
 
-export const Route = createFileRoute('/_auth/new-notification')({
+export const Route = createFileRoute("/_auth/new-notification")({
   component: NewNotificationView,
-})
+});
 
 function NewNotificationView() {
-
   return (
     <>
       <h1>Add New Notification</h1>
       <AddNewNotificationForm />
     </>
-  )
+  );
 }
 
 function AddNewNotificationForm() {
+  const [selectedGuest, setSelectedGuest] = useState<Guest | null>(null);
 
-  const [selectedGuestOpt, setSelectedGuestOpt] = useState<ReactSelectOption | null>();
   const [message, setMessage] = useState("");
   const [feedbackMessage, setFeedbackMessage] = useState({
     text: "",
-    isError: false
-  })
+    isError: false,
+  });
 
   const handleCreateNotification = async (e) => {
-    if (selectedGuestOpt === undefined) {
+    e.preventDefault();
+
+    if (!selectedGuest) {
       setFeedbackMessage({
         text: "Notification must include a guest",
-        isError: true
+        isError: true,
       });
       return;
     }
 
-    const response = await (
+    const response = (
       await API.post({
-        apiName: 'auth',
-        path: '/addGuestNotification',
+        apiName: "auth",
+        path: "/addGuestNotification",
         options: {
           body: {
-            guest_id: +selectedGuestOpt.value,
+            guest_id: selectedGuest.guest_id,
             message: message,
-            status: 'Active',
+            status: "Active",
           },
         },
       }).response
-    ).statusCode
+    ).statusCode;
 
     if (response === 200) {
       setFeedbackMessage({
         text: "Notification created!",
-        isError: false
+        isError: false,
       });
-      setSelectedGuestOpt(null);
+      setSelectedGuest(null);
       setMessage("");
     }
-  }
-
-  const handleEnter = (e) => {
-    if (e.key === "Enter") {
-      e.preventDefault()
-      handleCreateNotification(e)
-    }
-  }
+  };
 
   return (
     <>
-      <FeedbackMessage
-        message={feedbackMessage}
-      />
+      <FeedbackMessage message={feedbackMessage} />
 
-      <GuestSelectSearch
-        newGuest={undefined}
-        selectedGuestOpt={selectedGuestOpt}
-        setSelectedGuestOpt={setSelectedGuestOpt}
-      />
-
-      <Form id="new-notification">
+      <Form id="new-notification" onSubmit={handleCreateNotification}>
+        <GuestSelectSearch
+          selectedGuest={selectedGuest}
+          onSelect={(guest) => setSelectedGuest(guest)}
+        />
         <Form.Group className="mb-3" controlId="message">
           <Form.Control
             type="text"
             value={message}
             onChange={(e) => setMessage(e.target.value)}
-            onKeyDown={handleEnter}
             placeholder="Message (optional)"
           />
         </Form.Group>
 
-        <Button variant="primary" onClick={handleCreateNotification}>
+        <Button type="submit" variant="primary">
           Create Notification
         </Button>
       </Form>
     </>
-  )
+  );
 }

--- a/src/routes/_auth.new-visit.tsx
+++ b/src/routes/_auth.new-visit.tsx
@@ -1,39 +1,46 @@
 import { useEffect, useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import Select from "react-select";
 import { Button, Form, Modal, Table } from "react-bootstrap";
+import Select from "react-select";
+import { getGuestData } from "../lib/api";
+import {
+  addGuestNotification,
+  toggleGuestNotificationStatus,
+} from "../lib/api/notification";
+import { addVisit } from "../lib/api/visit";
+import {
+  blankUserMessage,
+  readableDateTime,
+  sortByTimeDescending,
+  trimStringValues,
+} from "../lib/utils";
 import {
   FeedbackMessage,
-  NewGuestForm,
   GuestSelectSearch,
+  NewGuestForm,
 } from "../lib/components";
-import { addGuest, getGuestData, getGuestsWithQuery } from "../lib/api/guest";
-import { addVisit } from "../lib/api/visit";
-import { toggleGuestNotificationStatus } from "../lib/api/notification";
-import {
-  guestOptLabel,
-  readableDateTime,
-  trimStringValues,
-  convertServiceTypeToOption,
-} from "../lib/utils";
+
+const DEFAULT_SERVICE_NAME = "courtyard";
 
 interface LoaderData {
   serviceTypes: ServiceType[];
+  defaultService: ServiceType | null;
 }
-
-const DEFAULT_SERVICE_NAME = "Courtyard";
 
 export const Route = createFileRoute("/_auth/new-visit")({
   component: NewVisitView,
   loader: async ({ context }): Promise<LoaderData> => {
     let { serviceTypes } = context;
     serviceTypes = serviceTypes ?? [];
-    return { serviceTypes };
+    const defaultService =
+      serviceTypes.find((s) => s.name.toLowerCase() === DEFAULT_SERVICE_NAME) ??
+      null;
+    return { serviceTypes, defaultService };
   },
 });
 
 function NewVisitView() {
-  const { serviceTypes } = Route.useLoaderData();
+  const { serviceTypes, defaultService } = Route.useLoaderData();
 
   const [feedback, setFeedback] = useState<UserMessage>({
     text: "",
@@ -41,64 +48,19 @@ function NewVisitView() {
   });
 
   const [showNewGuestModal, setShowNewGuestModal] = useState(false);
-  const [newGuest, setNewGuest] = useState<Partial<Guest> | null>(null);
+  const [showAddNotificationModal, setShowNotificationModal] = useState(false);
 
-  const [selectedGuestOpt, setSelectedGuestOpt] =
-    useState<ReactSelectOption | null>(null);
-  const [selectedServicesOpt, setSelectedServicesOpt] = useState<
-    ReactSelectOption[]
-  >([]); // array bc this Select is set to multi
+  const [selectedGuest, setSelectedGuest] = useState<
+    Guest | Partial<Guest> | null
+  >(null);
 
-  const [notifications, setNotifications] = useState<GuestNotification[]>([]);
+  const [notifications, setNotifications] = useState<
+    GuestNotification[] | Partial<GuestNotification>[]
+  >([]);
 
-  const getDefaultService: () => ServiceType | undefined = () => {
-    if (!serviceTypes.length) return;
-    let defaultService = serviceTypes.find(
-      (s) => s.name === DEFAULT_SERVICE_NAME
-    );
-    if (!defaultService) defaultService = serviceTypes[0];
-    return defaultService;
-  };
-  const setDefaultService = () => {
-    const defaultService = getDefaultService();
-    if (!defaultService) {
-      setSelectedServicesOpt([]);
-    } else {
-      setSelectedServicesOpt([convertServiceTypeToOption(defaultService)]);
-    }
-  };
-
-  // set selected guest to new guest if exists
-  useEffect(() => {
-    if (!newGuest) return;
-    setSelectedGuestOpt({
-      value: newGuest.guest_id?.toString()!,
-      label: guestOptLabel(newGuest),
-    });
-  }, [newGuest]);
-
-  // get notifications from selected guest
-  useEffect(() => {
-    if (!selectedGuestOpt) return;
-    getGuestData(+selectedGuestOpt.value).then((g) => {
-      if (!g.guest_notifications) return; // new guest is partial, so no notifications key
-      setNotifications(
-        (g.guest_notifications as GuestNotification[]).filter(
-          (n: GuestNotification) => n.status === "Active"
-        )
-      );
-    });
-  }, [selectedGuestOpt]);
-
-  // default to the first service being selected
-  useEffect(() => {
-    if (!serviceTypes.length) return;
-    let defaultService = getDefaultService();
-    if (!defaultService) {
-      defaultService = serviceTypes[0];
-    }
-    setSelectedServicesOpt([convertServiceTypeToOption(defaultService)]);
-  }, []);
+  const [selectedServiceIds, setSelectedServiceIds] = useState<number[]>(
+    defaultService?.service_id ? [defaultService.service_id] : []
+  );
 
   return (
     <>
@@ -116,156 +78,290 @@ function NewVisitView() {
       <Modal show={showNewGuestModal}>
         <NewGuestForm
           onSubmit={onSubmitNewGuestForm}
-          onClose={onCloseNewGuestForm}
+          onCancel={() => setShowNewGuestModal(false)}
         />
       </Modal>
 
-      <GuestSelectSearch
-        newGuest={newGuest}
-        selectedGuestOpt={selectedGuestOpt}
-        setSelectedGuestOpt={setSelectedGuestOpt}
+      <div className="mb-5">
+        <GuestSelectSearch
+          selectedGuest={selectedGuest}
+          onSelect={onSelectGuest}
+        />
+      </div>
+
+      <Modal show={showAddNotificationModal}>
+        <NotificationForm
+          guest={selectedGuest as Partial<Guest>}
+          onCancel={() => setShowNotificationModal(false)}
+          onSubmit={onSubmitNotificationForm}
+        />
+      </Modal>
+
+      {selectedGuest && (
+        <Notifications
+          notifications={notifications}
+          showForm={() => setShowNotificationModal(true)}
+        />
+      )}
+
+      <RequestedServices
+        serviceTypes={serviceTypes}
+        defaultService={defaultService}
+        selectedServiceIds={selectedServiceIds}
+        onSelect={onSelectServices}
       />
 
-      {!!notifications.length && <Notifications data={notifications} />}
-
-      <RequestedServices data={serviceTypes} />
+      <Button
+        type="submit"
+        onClick={logVisit}
+        className="mt-4 d-block m-auto"
+        disabled={!selectedServiceIds.length || !selectedGuest}
+      >
+        Log Visit
+      </Button>
     </>
   );
 
-  async function onSubmitNewGuestForm(
-    guest: Partial<Guest>
-  ): Promise<number | null> {
-    trimStringValues(guest);
-    const guest_id = await addGuest(guest);
-    if (!guest_id) return null;
+  function onSubmitNewGuestForm(newGuest: Partial<Guest>) {
     setShowNewGuestModal(false);
     setFeedback({
-      text: `Guest created successfully! ID: ${guest_id}`,
+      text: `Guest created successfully! ID: ${newGuest.guest_id}`,
       isError: false,
     });
-    const newGuest: Partial<Guest> = { ...guest, guest_id };
-    setNewGuest(newGuest);
-    return guest_id;
+    setSelectedGuest(newGuest);
   }
 
-  function onCloseNewGuestForm() {
-    if (!confirm("Discard the new guest?")) return;
-    setShowNewGuestModal(false);
-  }
-
-  function Notifications({ data }) {
-    return (
-      <div className="pb-5">
-        <h2>Notifications ({notifications.length})</h2>
-        <Table>
-          <tbody>
-            {notifications.map((n: GuestNotification) => {
-              const [date, time] = readableDateTime(n.created_at).split(" ");
-              return (
-                <tr key={n.notification_id} className="align-middle">
-                  <td>
-                    {date} <br /> {time}
-                  </td>
-                  <td>{n.message}</td>
-                  <td>
-                    <Form.Select
-                      onChange={async () =>
-                        await updateNotificationStatus(
-                          n.notification_id,
-                          n.status
-                        )
-                      }
-                      style={{ minWidth: "11ch" }}
-                      data-notification-id={n.notification_id}
-                    >
-                      <option value="Active">ACTIVE</option>
-                      <option value="Archived">Archive</option>
-                    </Form.Select>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </Table>
-      </div>
-    );
-
-    async function updateNotificationStatus(
-      notificationId: number,
-      status: GuestNotificationStatus
-    ) {
-      const success = await toggleGuestNotificationStatus(notificationId);
-      if (success) return;
-      // unsuccessful -> revert value
-      const notificationSelect = document.querySelector(
-        `[data-notification-id="${notificationId}"]`
-      ) as HTMLSelectElement | null;
-      notificationSelect!.value = status;
-    }
-  }
-
-  function RequestedServices({ data }) {
-    return (
-      <div>
-        <h2>Requested Services</h2>
-        <p>
-          <i>Select at least 1</i>
-        </p>
-        <Select
-          isMulti
-          options={servicesOpts()}
-          value={selectedServicesOpt}
-          onChange={(newVal: []) => {
-            setSelectedServicesOpt(newVal);
-          }}
-        />
-        <Button
-          type="submit"
-          onClick={logVisit}
-          className="mt-4 d-block m-auto"
-          disabled={!selectedServicesOpt.length || !selectedGuestOpt}
-        >
-          Log Visit
-        </Button>
-      </div>
-    );
-
-    /** Map services to `Select` options */
-    function servicesOpts() {
-      return (
-        serviceTypes?.map((s: ServiceType) => convertServiceTypeToOption(s)) ??
-        []
+  async function onSelectGuest(guest: Guest | Partial<Guest>) {
+    setSelectedGuest(guest);
+    const { guest_notifications } = (await getGuestData(guest.guest_id!))!;
+    guest_notifications?.length &&
+      setNotifications(
+        sortByTimeDescending(
+          guest_notifications.filter((n) => n.status === "Active"),
+          "created_at"
+        ) as GuestNotification[]
       );
-    }
+  }
 
-    async function logVisit(e) {
-      e.preventDefault();
-      if (!selectedServicesOpt.length) return;
-      // TODO validate "form"
-      const v: Partial<Visit> = {
-        guest_id: +selectedGuestOpt!.value,
-        service_ids: selectedServicesOpt.map(({ value }) => +value),
-      };
-      const visitId = await addVisit(v);
-      if (!visitId) {
-        setFeedback({
-          text: "Failed to create the visit. Try again in a few.",
-          isError: true,
-        });
-        return;
-      }
-      setShowNewGuestModal(false);
+  function onSubmitNotificationForm(
+    newNotification: Partial<GuestNotification>
+  ) {
+    setShowNotificationModal(false);
+    setFeedback({
+      text: `Notification created successfully! ID: ${newNotification.notification_id}`,
+      isError: false,
+    });
+    setNotifications([newNotification as GuestNotification, ...notifications]);
+  }
+
+  function onSelectServices(serviceIds: number[]) {
+    setSelectedServiceIds(serviceIds);
+  }
+
+  async function logVisit() {
+    if (!selectedServiceIds.length || !selectedGuest) return;
+    const visit: Partial<Visit> = {
+      guest_id: selectedGuest?.guest_id,
+      service_ids: selectedServiceIds,
+    };
+    const visitId = await addVisit(visit);
+    if (!visitId) {
       setFeedback({
-        text: `Visit created successfully! ID: ${visitId}`,
-        isError: false,
+        text: "Failed to create the visit. Try again in a few.",
+        isError: true,
       });
-      clear();
+      return;
     }
+    setFeedback({
+      text: `Visit created successfully! ID: ${visitId}`,
+      isError: false,
+    });
+    clear();
   }
 
   function clear() {
-    setSelectedGuestOpt(null);
-    setDefaultService();
+    setSelectedGuest(null);
     setNotifications([]);
+    setSelectedServiceIds(defaultService ? [defaultService.service_id] : []);
   }
+}
+
+interface NFProps {
+  guest: Guest | Partial<Guest>;
+  onCancel: () => void;
+  onSubmit: (notification: GuestNotification) => void;
+}
+function NotificationForm({ guest, onCancel, onSubmit }: NFProps) {
+  const [feedback, setFeedback] = useState<UserMessage>(blankUserMessage());
+  return (
+    <div className="p-3">
+      <h3 className="mb-3">New Notification</h3>
+      <h4>
+        To: {guest.first_name ?? ""} {guest.last_name ?? ""}
+      </h4>
+      <FeedbackMessage message={feedback} className="my-3" />
+      <Form onSubmit={async (e) => await submitForm(e)}>
+        <Form.Control name="guest_id" value={guest.guest_id} hidden readOnly />
+        <Form.Control name="status" value={"Active"} hidden readOnly />
+        <Form.Group className="mb-3">
+          <Form.Label>Message</Form.Label>
+          <Form.Control
+            name="message"
+            as="textarea"
+            minLength={4}
+            maxLength={256}
+          />
+        </Form.Group>
+        <div className="d-flex justify-content-between">
+          <Button variant="danger" type="button" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button variant="primary" type="submit">
+            Submit
+          </Button>
+        </div>
+      </Form>
+    </div>
+  );
+
+  async function submitForm(e) {
+    e.preventDefault();
+    const notification = Object.fromEntries(
+      new FormData(e.target) as any
+    ) as GuestNotification;
+    trimStringValues(notification);
+    if (!notification.message.length) {
+      setFeedback({ text: "A message is required.", isError: true });
+      return;
+    }
+    const notification_id = await addGuestNotification(notification);
+    if (!notification_id) {
+      setFeedback({
+        text: "Failed to add the notification. Try again in a few.",
+        isError: true,
+      });
+      return;
+    }
+    setFeedback(blankUserMessage());
+    onSubmit({ ...notification, notification_id });
+  }
+}
+
+interface NProps {
+  notifications: GuestNotification[] | Partial<GuestNotification>[];
+  showForm: () => void;
+}
+function Notifications({ notifications, showForm }: NProps) {
+  return (
+    <div className="pb-5">
+      <div className="d-flex justify-content-between align-items-center mb-2">
+        <h2>Notifications ({notifications.length})</h2>
+        <Button onClick={showForm}>Add Notification</Button>
+      </div>
+      <Table>
+        <tbody>
+          {notifications.map((n: GuestNotification) => {
+            const [date, time] = readableDateTime(n.created_at).split(" ");
+            return (
+              <tr key={n.notification_id} className="align-middle">
+                <td>
+                  {date} <br /> {time}
+                </td>
+                <td>{n.message}</td>
+                <td>
+                  <Form.Select
+                    onChange={async () =>
+                      await updateNotificationStatus(
+                        n.notification_id,
+                        n.status
+                      )
+                    }
+                    style={{ minWidth: "11ch" }}
+                    data-notification-id={n.notification_id}
+                  >
+                    <option value="Active">ACTIVE</option>
+                    <option value="Archived">Archive</option>
+                  </Form.Select>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </Table>
+    </div>
+  );
+
+  async function updateNotificationStatus(
+    notificationId: number,
+    status: GuestNotificationStatus
+  ) {
+    const success = await toggleGuestNotificationStatus(notificationId);
+    if (success) return;
+    // unsuccessful -> revert value
+    const notificationSelect = document.querySelector(
+      `[data-notification-id="${notificationId}"]`
+    ) as HTMLSelectElement | null;
+    notificationSelect!.value = status;
+  }
+}
+
+interface SProps {
+  serviceTypes: ServiceType[];
+  defaultService: ServiceType | null;
+  selectedServiceIds: number[];
+  onSelect: (serviceIds: number[]) => void;
+}
+function RequestedServices({
+  serviceTypes,
+  defaultService,
+  selectedServiceIds,
+  onSelect,
+}: SProps) {
+  const [selectedServicesOpts, setSelectedServicesOpts] = useState<
+    ReactSelectOption[]
+  >(defaultService ? [serviceTypeOptionFrom(defaultService)] : []);
+
+  // update select opts when selected service IDs array changes
+  useEffect(() => {
+    setSelectedServicesOpts(
+      serviceTypes
+        .filter((s) => selectedServiceIds.includes(s.service_id))
+        .map((s) => serviceTypeOptionFrom(s))
+    );
+  }, [selectedServiceIds]);
+
+  return (
+    <div>
+      <h2 className="mb-4">Requested Services</h2>
+      <Form.Group>
+        <Form.Label className="fst-italic">Select at least 1</Form.Label>
+        <Select
+          isMulti
+          options={servicesOpts()}
+          value={selectedServicesOpts}
+          onChange={onChange}
+        />
+      </Form.Group>
+    </div>
+  );
+
+  function onChange(selections: ReactSelectOption[]) {
+    setSelectedServicesOpts(selections);
+    const selectedServiceIds = selections.map((s) => +s.value);
+    onSelect(selectedServiceIds);
+  }
+
+  /** Map services to `Select` options */
+  function servicesOpts() {
+    return (
+      serviceTypes?.map((s: ServiceType) => serviceTypeOptionFrom(s)) ?? []
+    );
+  }
+}
+
+function serviceTypeOptionFrom(service: ServiceType): ReactSelectOption {
+  return {
+    value: service.service_id.toString(),
+    label: service.name,
+  };
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -91,8 +91,16 @@ interface GuestDataAPIResponse extends Guest {
   total: number;
 }
 
+interface GuestNotificationsAPIResponse extends PaginationInfo {
+  rows: GuestNotification[];
+}
+
 interface GuestsAPIResponse extends PaginationInfo {
   rows: Guest[];
+}
+
+interface AddGuestAPIResponse {
+  guest_id: number;
 }
 
 interface AddUserAPIResponse {
@@ -110,6 +118,10 @@ interface GetUsersAPIResponse {
 
 interface GetVisitsAPIResponse extends PaginationInfo {
   rows: Visit[];
+}
+
+interface AddGuestNotificationAPIResponse {
+  notification_id: number;
 }
 
 interface GuestResponse {
@@ -143,6 +155,10 @@ interface AppContext {
 interface ReactSelectOption {
   value: string;
   label: string;
+}
+
+interface GuestSelectOption extends ReactSelectOption {
+  guest: Partial<Guest>;
 }
 
 /** Feedback shown to the user on submit event or similar. */


### PR DESCRIPTION
… view + children + views that share children) (#210)

* formatting

* add: guest prop to and new type for Guest Select options

* WIP; add: useQuery to handle data fetching; likely not complete/correct

* refactor: factor out ID padding function

* change: useQuery more correct && remove extraneous props from Select

* WIP; New Visit view broken due to: refactor: move GuestSelectSearch selection state to self, leaving New Visit view only aware of selected guest && change callbacks passed to GuestSelectSearch

* fix: broken New Notification view; remove: unnecessary Enter key handler; change: make GuestSelectSearch a form group instead of whole form && move it inside New Notification form

* fix: restore bottom margin on Guest search in New Visit view

* refactor: change where default service is derived -- remove the useEffect and use the loader

* refactor: move Notifications out of parent definition

* WIP; working, but needs refactor; refactor: move RequestedServices out of parent definition;

* refactor: change props of RequestedServices to separate concerns && move Log Visit button to the view func where it belongs

* WIP; notifications are not reactive; add: working new notification form & modal

* fix: api/guests.ts: add try/catch everywhere it was missing -- still no status code handling

* fix: AddNewGuestForm onSubmit to match other forms

* change: pass the complete guest into NewGuestForm parent's onSubmit handler, to handle all guest-related api calls in the form

* remove: unecessary functions and rearrage some handlers

* fix: New Visit View notifications not reactive; revert: action stated in commit cc8d094 message; fix: sort notifications in New Visit view; fix: New Visit View: can't change status of notification created in this view

* fix: add remaining error messages to api/guest.ts

SORRY!